### PR TITLE
Remove upper bounds for dependencies

### DIFF
--- a/snaplet-sass.cabal
+++ b/snaplet-sass.cabal
@@ -37,13 +37,13 @@ library
     Paths_snaplet_sass
 
   build-depends:
-      base         >= 4       && < 5
-    , bytestring   >= 0.9     && < 0.11
-    , configurator >= 0.2     && < 0.4
-    , directory    >= 1.1     && < 1.3
-    , filepath     >= 1.3     && < 1.5
-    , mtl          >= 2.1     && < 2.3
-    , process      >= 1.1     && <= 1.3
-    , snap         >= 0.11.1  && < 0.15
-    , snap-core    >= 0.9.3.1 && < 0.10
-    , transformers >= 0.3     && < 0.4 || > 0.4.1 && < 0.5
+      base         >= 4
+    , bytestring   >= 0.9
+    , configurator >= 0.2
+    , directory    >= 1.1
+    , filepath     >= 1.3
+    , mtl          >= 2.1
+    , process      >= 1.1
+    , snap         >= 0.11.1
+    , snap-core    >= 0.9.3.1
+    , transformers >= 0.3

--- a/snaplet-sass.cabal
+++ b/snaplet-sass.cabal
@@ -1,5 +1,5 @@
 name:                snaplet-sass
-version:             0.1.1.0
+version:             0.1.2.0
 synopsis:            Sass integration for Snap with request- and pre-compilation.
 description:         Sass integration for Snap with request based compilation during development and precompilation in production.
                      For more information, please see <https://github.com/lukerandall/snaplet-sass>.


### PR DESCRIPTION
This package will no longer compile on latest repositories without removing these upper bounds.